### PR TITLE
Refactors and Separation of `is_row_in`

### DIFF
--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -25,10 +25,14 @@ def ismember(a_vec, b_vec, method=None):
         'elementwise': For each row, all elements are compared.
         'rows': Row-wise matrice comparison.
 
-    Returns an array containing logical 1 (true) where the data in A is found in B. Elsewhere,
-    the array contains logical 0 (false)
+    Returns
     -------
-    Tuple
+    Iloc: np.ndarray
+        Array containing logical 1 (true) where the data in A is found in B.
+        Elsewhere, the array contains logical 0 (false)
+    idx: np.ndarray
+        Array containing the lowest index in B for each value in A that is
+        a member of B.
 
     Example
     -------

--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -14,7 +14,8 @@ def ismember(a_vec, b_vec, method=None):
     Description
     -----------
     MATLAB equivalent ismember function
-    [LIA, LOCB] = ISMEMBER(A,B) also returns an array LOCB containing the lowest absolute index in B for each element in
+    [LIA, LOCB] = ISMEMBER(A,B) also returns an array LOCB containing
+    the lowest absolute index in B for each element in
     A which is a member of B and 0 if there is no such index.
 
     Parameters

--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -80,15 +80,6 @@ def _elementwise(a_vec, b_vec):
 
 # %% Row-wise comparison
 def _row_wise(a_vec, b_vec):
-    def is_row_in(a, b):
-        # Get the unique row index
-        _, rev = np.unique(np.concatenate((b, a)), axis=0, return_inverse=True)
-        # Split the index
-        a_rev = rev[len(b):]
-        b_rev = rev[:len(b)]
-        # Return the result:
-        return np.isin(a_rev, b_rev)
-
     # Step 1: Find row-wise the elements of a_vec in b_vec
     bool_ind = is_row_in(a_vec, b_vec)
     common = a_vec[bool_ind]
@@ -104,10 +95,10 @@ def _row_wise(a_vec, b_vec):
 # %% Typing
 def _settypes(a_vec, b_vec):
     if 'pandas' in str(type(a_vec)):
-        a_vec.values[np.where(a_vec.values==None)] = 'NaN'
+        a_vec.values[np.where(a_vec.values == None)] = 'NaN'
         a_vec = np.array(a_vec.values)
     if 'pandas' in str(type(b_vec)):
-        b_vec.values[np.where(b_vec.values==None)] = 'NaN'
+        b_vec.values[np.where(b_vec.values == None)] = 'NaN'
         b_vec = np.array(b_vec.values)
     if isinstance(a_vec, list):
         a_vec = np.array(a_vec)
@@ -133,3 +124,18 @@ def _compute(a_vec, b_vec):
     [b_unique, b_ind] = np.unique(b_vec, return_index=True)
     common_ind = b_ind[np.isin(b_unique, common_unique, assume_unique=True)]
     return bool_ind, common_ind[common_inv]
+
+
+def is_row_in(a, b):
+    """
+    Calculates `a` in `b`, broadcasting over `a` only.
+    Returns a boolean array of the same shape as `a` that is True
+    where a row of `a` is in `b` and False otherwise.
+    """
+    # Get the unique row index
+    _, rev = np.unique(np.concatenate((b, a)), axis=0, return_inverse=True)
+    # Split the index
+    a_rev = rev[len(b):]
+    b_rev = rev[:len(b)]
+    # Return the result:
+    return np.isin(a_rev, b_rev)

--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -51,16 +51,13 @@ def ismember(a_vec, b_vec, method=None):
     # Compute
     if method is None:
         a_vec, b_vec = _settypes(a_vec, b_vec)
-        Iloc, idx = _compute(a_vec, b_vec)
-    elif method=='rows':
+        return _compute(a_vec, b_vec)
+    if method=='rows':
         a_vec, b_vec = _settypes(a_vec, b_vec)
-        Iloc, idx = _row_wise(a_vec, b_vec)
+        return _row_wise(a_vec, b_vec)
     elif method=='elementwise':
-        Iloc, idx = _elementwise(a_vec, b_vec)
-    else:
-        Iloc, idx = None, None
-
-    return(Iloc, idx)
+        return _elementwise(a_vec, b_vec)
+    return None, None
 
 
 # %% Row-wise comparison

--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 
+
 # %% ismember
 def ismember(a_vec, b_vec, method=None):
     """Ismember: MATLAB equivalent function
@@ -52,10 +53,10 @@ def ismember(a_vec, b_vec, method=None):
     if method is None:
         a_vec, b_vec = _settypes(a_vec, b_vec)
         return _compute(a_vec, b_vec)
-    if method=='rows':
+    if method == 'rows':
         a_vec, b_vec = _settypes(a_vec, b_vec)
         return _row_wise(a_vec, b_vec)
-    elif method=='elementwise':
+    elif method == 'elementwise':
         return _elementwise(a_vec, b_vec)
     return None, None
 
@@ -63,7 +64,7 @@ def ismember(a_vec, b_vec, method=None):
 # %% Row-wise comparison
 def _elementwise(a_vec, b_vec):
     # Append nan to b_vec to make shape similar
-    if a_vec.shape[0]>b_vec.shape[0]:
+    if a_vec.shape[0] > b_vec.shape[0]:
         nanrows = [[0] * b_vec.shape[1]] * (a_vec.shape[0] - b_vec.shape[0])
         b_vec = np.concatenate((b_vec, nanrows))
 
@@ -103,22 +104,22 @@ def _row_wise(a_vec, b_vec):
 # %% Typing
 def _settypes(a_vec, b_vec):
     if 'pandas' in str(type(a_vec)):
-        a_vec.values[np.where(a_vec.values==None)]='NaN'
+        a_vec.values[np.where(a_vec.values==None)] = 'NaN'
         a_vec = np.array(a_vec.values)
     if 'pandas' in str(type(b_vec)):
-        b_vec.values[np.where(b_vec.values==None)]='NaN'
+        b_vec.values[np.where(b_vec.values==None)] = 'NaN'
         b_vec = np.array(b_vec.values)
     if isinstance(a_vec, list):
-        a_vec=np.array(a_vec)
+        a_vec = np.array(a_vec)
         # a_vec[a_vec==None]='NaN'
     if isinstance(b_vec, list):
-        b_vec=np.array(b_vec)
+        b_vec = np.array(b_vec)
         # b_vec[b_vec==None]='NaN'
 
     # Check dtypes. In case of O (Object), set to str.
-    if a_vec.dtype=='O':
+    if a_vec.dtype == 'O':
         a_vec = a_vec.astype(str)
-    if b_vec.dtype=='O':
+    if b_vec.dtype == 'O':
         b_vec = b_vec.astype(str)
 
     return a_vec, b_vec

--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -35,18 +35,24 @@ def ismember(a_vec, b_vec, method=None):
         Array containing the lowest index in B for each value in A that is
         a member of B.
 
-    Example
-    -------
-    >>> a_vec = np.array([1,2,3,None])
+    Examples
+    --------
+    >>> a_vec = np.array([1,2,3])
     >>> b_vec = np.array([4,1,2])
     >>> Iloc, idx = ismember(a_vec,b_vec)
-    >>> a_vec[Iloc] == b_vec[idx]
-    >>>
+    >>> Iloc
+    array([ True,  True, False])
+    >>> idx
+    array([1, 2])
+
     >>> # Row wise comparison
     >>> a_vec = np.array(((1, 2, 3), (4, 5, 6), (7, 8, 9), (10, 11, 12)))
     >>> b_vec = np.array(((4, 5, 6), (7, 8, 0)))
     >>> Iloc, idx = ismember(a_vec, b_vec, 'rows')
-    >>> a_vec[Iloc]==b_vec[idx]
+    >>> idx
+    array([0])
+    >>> Iloc
+    array([False, True, False, False])
 
     References
     ----------

--- a/ismember/ismember.py
+++ b/ismember/ismember.py
@@ -140,8 +140,8 @@ def _compute(a_vec, b_vec):
 def is_row_in(a, b):
     """
     Calculates `a` in `b`, broadcasting over `a` only.
-    Returns a boolean array of the same shape as `a` that is True
-    where a row of `a` is in `b` and False otherwise.
+    Returns a boolean array that is True where a row
+    of `a` is in `b` and False otherwise.
     """
     # Get the unique row index
     _, rev = np.unique(np.concatenate((b, a)), axis=0, return_inverse=True)

--- a/ismember/tests/test_ismember.py
+++ b/ismember/tests/test_ismember.py
@@ -22,7 +22,7 @@ class TestCLUSTIMAGE(unittest.TestCase):
 		# Test 3
 		a_vec   = np.array([1,2,3,None])
 		b_vec   = np.array([1,2,4])
-		[, idx = ismember(a_vec,b_vec)
+		I, idx = ismember(a_vec,b_vec)
 		assert np.all(a_vec[I]==b_vec[idx])
 
 		# Test 4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ rst2pdf
 spyder-kernels
 sphinx
 pytest
+pandas


### PR DESCRIPTION
This PR fixes the unit tests and suggests the following changes to the code:

- style: In the docstring, add some words about the returned variables
- feature: separate the function `is_row_in` to make it available as stand-alone function
- refactor: add "early returns" in `ismember`