### PR TITLE
Bugfix: importable`is_row_in`

### DIFF
--- a/ismember/__init__.py
+++ b/ismember/__init__.py
@@ -1,4 +1,4 @@
-from ismember.ismember import ismember
+from ismember.ismember import ismember, is_row_in
 
 __author__ = 'Erdogan Tasksen'
 __email__ = 'erdogant@gmail.com'


### PR DESCRIPTION
As was already intended by https://github.com/erdogant/ismember/pull/3, this PR makes `ismember.is_row_in` importable via `from ismember import is_row_in`